### PR TITLE
JUnit cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,10 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.jackson.databind)
     testImplementation(libs.jackson.dataformat.xml)
-    testImplementation(libs.junit.jupiter)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation(libs.hivemq.edge.adapterSdk)
     testImplementation(libs.mockito.junitJupiter)
 }


### PR DESCRIPTION
Cleaned up Junit deps to fix incompatibility between gradle and JUnit 5.12.1.
Moved deps to JUnit-bom for cleaner hierarchy.