### PR TITLE
Switch to different deps and make tests not rely on the system locale

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,8 +42,8 @@ dependencies {
     compileOnly(libs.jackson.databind)
     compileOnly(libs.jackson.dataformat.xml)
     // V4 supports XSD 1.1
-    implementation(libs.jakarta.xml.bind.api.v4)
-    implementation(libs.jaxb.impl.v4)
+    implementation(libs.jaxb4.impl)
+    implementation(libs.jaxb4.bind)
 }
 
 dependencies {

--- a/src/test/java/com/hivemq/mtconnect/protocol/schemas/MtConnectSchemaTest.java
+++ b/src/test/java/com/hivemq/mtconnect/protocol/schemas/MtConnectSchemaTest.java
@@ -15,17 +15,19 @@
  */
 package com.hivemq.mtconnect.protocol.schemas;
 
-import com.hivemq.mtconnect.protocol.schemas.MtConnectSchema;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -33,6 +35,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MtConnectSchemaTest {
+
+    Locale orginalLocale;
+
+    @BeforeEach
+    public void before() throws Throwable {
+        orginalLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("en", "US"));
+    };
+
+    @AfterEach
+    protected void after() {
+        Locale.setDefault(orginalLocale);
+    };
+
+
     @Test
     public void whenInputXmlIsAssets_1_2_thenXmlValidationShouldPass() throws Exception {
         final Unmarshaller unmarshaller = MtConnectSchema.Assets_1_2.getUnmarshaller();


### PR DESCRIPTION
MTConnect must use the same JAXB version as hivemq-edge.
I also fixed the test to not rely on the system locale.